### PR TITLE
[#40] Consistent column order for MBCUSTOMQUERY

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -469,7 +469,12 @@ function MBCUSTOMQUERY(events, groupBy, orderBy, limit, offset) {
 
   // turn the array of objects into a flat array
   const objArr = results.result.rows;
-  return objectArrayToArray(objArr);
+  const headersPreset = Array(payload.events[0].select.length);
+  // eslint-disable-next-line no-restricted-syntax, guard-for-in
+  for (const s of payload.events[0].select) {
+    headersPreset[s.inputIndex] = s.alias;
+  }
+  return objectArrayToArray(objArr, headersPreset);
 }
 
 /**

--- a/src/Code.spec.js
+++ b/src/Code.spec.js
@@ -241,10 +241,10 @@ function testRunner(testSheetURL) {
         0,
       ],
       expected: [
-        ['amount', 'sender'],
-        [1e+27, '0x89d048be68575f2b56a999ba24faacabd1b919fb'],
-        [1000000000000000000, '0xa616eed6ad7a0cf5d2388301a710c273ca955e05'],
-        [1000000000000000000, '0xbac1cd4051c378bf900087ccc445d7e7d02ad745'],
+        ['sender', 'amount'],
+        ['0x89d048be68575f2b56a999ba24faacabd1b919fb', 1e+27],
+        ['0xa616eed6ad7a0cf5d2388301a710c273ca955e05', 1000000000000000000],
+        ['0xbac1cd4051c378bf900087ccc445d7e7d02ad745', 1000000000000000000],
       ],
     },
     {

--- a/src/library/Util.js
+++ b/src/library/Util.js
@@ -386,11 +386,16 @@ function eventsToArray(entries) {
   return rows;
 }
 
-function objectArrayToArray(objArr) {
+function objectArrayToArray(objArr, headersPreset) {
   const rows = [];
 
   // header row: just take the keys from the first row
-  const headers = keysFromObj(objArr[0], true);
+  let headers;
+  if (!Array.isArray(headersPreset)) {
+    headers = keysFromObj(objArr[0], false);
+  } else {
+    headers = headersPreset;
+  }
   rows.push(headers);
 
   // body rows


### PR DESCRIPTION
Resolves #40 

Result columns will be ordered based on what input `index` is set for `MBCUSTOMQUERY`