### PR TITLE
[noissue] swap gas-tap URL for an immutable one

### DIFF
--- a/src/Code.spec.js
+++ b/src/Code.spec.js
@@ -20,7 +20,7 @@ function initTest(customLogger) {
   // GasT Initialization.
   if ((typeof GasTap) === 'undefined') {
     // eslint-disable-next-line no-eval
-    eval(UrlFetchApp.fetch('https://raw.githubusercontent.com/zixia/gast/master/src/gas-tap-lib.js').getContentText());
+    eval(UrlFetchApp.fetch('https://raw.githubusercontent.com/huan/gast/93bcc59f1081e1ca3be38b31944ee396d128f5ae/src/gas-tap-lib.js').getContentText());
   }
 
   if (typeof customLogger !== 'function') {


### PR DESCRIPTION
Use an immutable URL instead of `master`. I thought about using the latest tag, but it was last tagged 5 years ago and the latest stable version was updated 8 months ago.